### PR TITLE
add more stats on achat boeuf

### DIFF
--- a/index.html
+++ b/index.html
@@ -1422,6 +1422,55 @@
                             </div>
                          </div>
                          <hr>
+                         <!-- Statistiques détaillées pour la période -->
+                         <div id="achat-boeuf-statistiques-periode" class="mt-4">
+                            <h5 class="mb-3">Statistiques détaillées pour la période</h5>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="card">
+                                        <div class="card-header">Nombre de bêtes</div>
+                                        <div class="card-body">
+                                            <p>Bœufs: <span id="nombre-boeufs">0</span></p>
+                                            <p>Veaux: <span id="nombre-veaux">0</span></p>
+                                            <p><strong>Total: <span id="nombre-total">0</span></strong></p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="card">
+                                        <div class="card-header">Poids</div>
+                                        <div class="card-body">
+                                            <p>Poids total vendu: <span id="poids-total">0</span> kg</p>
+                                            <p>Poids moyen par bête: <span id="poids-moyen">0</span> kg</p>
+                                            <p>Poids moyen bœuf: <span id="poids-moyen-boeuf">0</span> kg</p>
+                                            <p>Poids moyen veau: <span id="poids-moyen-veau">0</span> kg</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row mt-3">
+                                <div class="col-md-6">
+                                    <div class="card">
+                                        <div class="card-header">Prix totaux</div>
+                                        <div class="card-body">
+                                            <p>Prix total des abats: <span id="prix-total-abats">0</span> FCFA</p>
+                                            <p>Frais d'abattage total: <span id="frais-abattage-total">0</span> FCFA</p>
+                                            <p><strong>Prix total d'achat: <span id="prix-total-achat">0</span> FCFA</strong></p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="card">
+                                        <div class="card-header">Prix moyens par bête</div>
+                                        <div class="card-body">
+                                            <p>Prix moyen d'un bœuf: <span id="prix-moyen-boeuf">0</span> FCFA</p>
+                                            <p>Prix moyen d'un veau: <span id="prix-moyen-veau">0</span> FCFA</p>
+                                            <p>Prix moyen global: <span id="prix-moyen-global">0</span> FCFA</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                         </div>
                          <!-- Date Filter Section -->
                          <div class="row mb-3 align-items-end">
                              <div class="col-md-3">

--- a/public/js/suiviAchatBoeuf.js
+++ b/public/js/suiviAchatBoeuf.js
@@ -399,6 +399,53 @@ function calculateAndDisplayStats(achats) {
     document.getElementById('veau-mean').textContent = veauPrices.length > 0 ? veauMean.toFixed(2) : 'N/A';
     document.getElementById('veau-median').textContent = veauPrices.length > 0 ? veauMedian.toFixed(2) : 'N/A';
     document.getElementById('veau-stddev').textContent = veauPrices.length > 0 ? veauStdDev.toFixed(2) : 'N/A';
+
+    // === NOUVELLES STATISTIQUES DÉTAILLÉES ===
+    
+    // Nombre de bêtes
+    const nombreBoeufs = boeufData.length;
+    const nombreVeaux = veauData.length;
+    const nombreTotal = nombreBoeufs + nombreVeaux;
+    
+    document.getElementById('nombre-boeufs').textContent = nombreBoeufs;
+    document.getElementById('nombre-veaux').textContent = nombreVeaux;
+    document.getElementById('nombre-total').textContent = nombreTotal;
+
+    // Calculs des poids
+    const poidsBoeuf = boeufData.map(a => parseFloat(a.nbr_kg) || 0);
+    const poidsVeau = veauData.map(a => parseFloat(a.nbr_kg) || 0);
+    const poidsTousAnimaux = achats.map(a => parseFloat(a.nbr_kg) || 0);
+    
+    const poidsTotal = poidsTousAnimaux.reduce((sum, poids) => sum + poids, 0);
+    const poidsMoyenGlobal = nombreTotal > 0 ? poidsTotal / nombreTotal : 0;
+    const poidsMoyenBoeuf = nombreBoeufs > 0 ? poidsBoeuf.reduce((sum, poids) => sum + poids, 0) / nombreBoeufs : 0;
+    const poidsMoyenVeau = nombreVeaux > 0 ? poidsVeau.reduce((sum, poids) => sum + poids, 0) / nombreVeaux : 0;
+    
+    document.getElementById('poids-total').textContent = poidsTotal.toFixed(2);
+    document.getElementById('poids-moyen').textContent = poidsMoyenGlobal.toFixed(2);
+    document.getElementById('poids-moyen-boeuf').textContent = poidsMoyenBoeuf.toFixed(2);
+    document.getElementById('poids-moyen-veau').textContent = poidsMoyenVeau.toFixed(2);
+
+    // Prix totaux
+    const prixTotalAbats = achats.reduce((sum, a) => sum + (parseFloat(a.abats) || 0), 0);
+    const fraisAbattageTotal = achats.reduce((sum, a) => sum + (parseFloat(a.frais_abattage) || 0), 0);
+    const prixTotalAchat = achats.reduce((sum, a) => sum + (parseFloat(a.prix) || 0), 0);
+    
+    document.getElementById('prix-total-abats').textContent = prixTotalAbats.toLocaleString('fr-FR');
+    document.getElementById('frais-abattage-total').textContent = fraisAbattageTotal.toLocaleString('fr-FR');
+    document.getElementById('prix-total-achat').textContent = prixTotalAchat.toLocaleString('fr-FR');
+
+    // Prix moyens par bête
+    const prixTotalBoeuf = boeufData.reduce((sum, a) => sum + (parseFloat(a.prix) || 0), 0);
+    const prixTotalVeau = veauData.reduce((sum, a) => sum + (parseFloat(a.prix) || 0), 0);
+    
+    const prixMoyenBoeuf = nombreBoeufs > 0 ? prixTotalBoeuf / nombreBoeufs : 0;
+    const prixMoyenVeau = nombreVeaux > 0 ? prixTotalVeau / nombreVeaux : 0;
+    const prixMoyenGlobal = nombreTotal > 0 ? prixTotalAchat / nombreTotal : 0;
+    
+    document.getElementById('prix-moyen-boeuf').textContent = prixMoyenBoeuf.toLocaleString('fr-FR');
+    document.getElementById('prix-moyen-veau').textContent = prixMoyenVeau.toLocaleString('fr-FR');
+    document.getElementById('prix-moyen-global').textContent = prixMoyenGlobal.toLocaleString('fr-FR');
 }
 
 // Create price evolution charts for Boeuf and Veau

--- a/public/js/suiviAchatBoeuf.js
+++ b/public/js/suiviAchatBoeuf.js
@@ -399,7 +399,6 @@ function calculateAndDisplayStats(achats) {
     document.getElementById('veau-mean').textContent = veauPrices.length > 0 ? veauMean.toFixed(2) : 'N/A';
     document.getElementById('veau-median').textContent = veauPrices.length > 0 ? veauMedian.toFixed(2) : 'N/A';
     document.getElementById('veau-stddev').textContent = veauPrices.length > 0 ? veauStdDev.toFixed(2) : 'N/A';
-
     // === NOUVELLES STATISTIQUES DÉTAILLÉES ===
     
     // Nombre de bêtes
@@ -407,9 +406,14 @@ function calculateAndDisplayStats(achats) {
     const nombreVeaux = veauData.length;
     const nombreTotal = nombreBoeufs + nombreVeaux;
     
-    document.getElementById('nombre-boeufs').textContent = nombreBoeufs;
-    document.getElementById('nombre-veaux').textContent = nombreVeaux;
-    document.getElementById('nombre-total').textContent = nombreTotal;
+    const setBeteCounts = (elementId, value) => {
+        const element = document.getElementById(elementId);
+        if (element) element.textContent = value;
+    };
+    
+    setBeteCounts('nombre-boeufs', nombreBoeufs);
+    setBeteCounts('nombre-veaux', nombreVeaux);
+    setBeteCounts('nombre-total', nombreTotal);
 
     // Calculs des poids
     const poidsBoeuf = boeufData.map(a => {

--- a/public/js/suiviAchatBoeuf.js
+++ b/public/js/suiviAchatBoeuf.js
@@ -412,14 +412,27 @@ function calculateAndDisplayStats(achats) {
     document.getElementById('nombre-total').textContent = nombreTotal;
 
     // Calculs des poids
-    const poidsBoeuf = boeufData.map(a => parseFloat(a.nbr_kg) || 0);
-    const poidsVeau = veauData.map(a => parseFloat(a.nbr_kg) || 0);
-    const poidsTousAnimaux = achats.map(a => parseFloat(a.nbr_kg) || 0);
+    const poidsBoeuf = boeufData.map(a => {
+        const poids = parseFloat(a.nbr_kg);
+        return isNaN(poids) ? 0 : poids;
+    });
+    const poidsVeau = veauData.map(a => {
+        const poids = parseFloat(a.nbr_kg);
+        return isNaN(poids) ? 0 : poids;
+    });
+    const poidsTousAnimaux = achats.map(a => {
+        const poids = parseFloat(a.nbr_kg);
+        return isNaN(poids) ? 0 : poids;
+    });
     
     const poidsTotal = poidsTousAnimaux.reduce((sum, poids) => sum + poids, 0);
     const poidsMoyenGlobal = nombreTotal > 0 ? poidsTotal / nombreTotal : 0;
-    const poidsMoyenBoeuf = nombreBoeufs > 0 ? poidsBoeuf.reduce((sum, poids) => sum + poids, 0) / nombreBoeufs : 0;
-    const poidsMoyenVeau = nombreVeaux > 0 ? poidsVeau.reduce((sum, poids) => sum + poids, 0) / nombreVeaux : 0;
+    const poidsMoyenBoeuf = nombreBoeufs > 0
+      ? poidsBoeuf.reduce((sum, poids) => sum + poids, 0) / nombreBoeufs
+      : 0;
+    const poidsMoyenVeau = nombreVeaux > 0
+      ? poidsVeau.reduce((sum, poids) => sum + poids, 0) / nombreVeaux
+      : 0;
     
     document.getElementById('poids-total').textContent = poidsTotal.toFixed(2);
     document.getElementById('poids-moyen').textContent = poidsMoyenGlobal.toFixed(2);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a detailed statistics section for "Suivi des Achats de Bétail (Boeuf/Veau)" with numeric summaries for the selected period, including animal counts, weights, and purchase prices.
  - Statistics now display totals and averages for boeufs, veaux, and combined, as well as breakdowns for offal and slaughter fees.
- **Bug Fixes**
  - Ensured statistics display appropriate defaults (zero or "N/A") when data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->